### PR TITLE
use HTTP2 for underlying client

### DIFF
--- a/src/OpenPr0gramm/Pr0grammApiClient.cs
+++ b/src/OpenPr0gramm/Pr0grammApiClient.cs
@@ -41,6 +41,7 @@ namespace OpenPr0gramm
             };
 
             _client = new HttpClient(_clientHandler) { BaseAddress = new Uri(ClientConstants.ApiBaseUrl) };
+            _client.DefaultRequestVersion = HttpVersion.Version20;
             _client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
 
             User = RestService.For<IPr0grammUserService>(_client, _refitSettings); // Done


### PR DESCRIPTION
I had occasional issues with "Connection reset by peer" which got resolved for me after I changed the client to use HTTP/2. Since I see no downside and pr0 supports HTTP/2 i think we can make it a default.